### PR TITLE
添加 commit_log_fmt 配置项, 可以更灵活地指定“合并代码后提交的 svn log 格式”

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,17 @@ a. 将 B 分支 checkout 到本地目录, 并将路径填写至 `zzz` 的位置
 b. 将 A 分支的 svn url 填写至 `yyy` 的位置    
 c. 将 svn 用户名、密码填写至 `xxx` 的位置
 
-```
+```lua
 local config = {
-        svn_cmd = 'svn --username \"xxx\" --password \"xxx\" --no-auth-cache',
-        svn_url = "yyy", -- svn url 地址
-        svn_relative_to_root_path = "",
-        workdir = "zzz", -- 本地 svn 目录
-        report_file = "/path_to_report_file", -- 冲突报告日志
-        execlude_rule = {},
-        execlude_path = {},
-        last_merged_revision_store = "/path_to_last_merged_revision", -- 程序用于保存最后已经合并过的版本号
+		svn_cmd = 'svn --username \"xxx\" --password \"xxx\" --no-auth-cache',
+		svn_url = "yyy", -- svn url 地址
+		svn_relative_to_root_path = "",
+		workdir = "zzz", -- 本地 svn 目录
+		report_file = "/path_to_report_file", -- 冲突报告日志
+		execlude_rule = {},
+		execlude_path = {},
+		last_merged_revision_store = "/path_to_last_merged_revision", -- 程序用于保存最后已经合并过的版本号
+		commit_log_fmt = [[merge from ${from_svn_relative_to_root_path} ${from_revision}|${from_commit_log}]], -- 合并代码后提交的 svn log 格式
 }
 ```
 将以上内容保存为 `config.lua`   

--- a/auto_merge.lua
+++ b/auto_merge.lua
@@ -2,9 +2,12 @@ package.path = "./xml2lua/?.lua;" .. package.path
 local xml2lua = require("xml2lua")
 local xmlhandler = require("xmlhandler.tree")
 local string_gsub = string.gsub
+local string_format = string.format
+local table_insert = table.insert
+local table_sort = table.sort
 
 local function execute_command(fmt, ...)
-	local handle = io.popen(string.format(fmt, ...), "r")
+	local handle = io.popen(string_format(fmt, ...), "r")
 	local t = {}
 
 	for line in handle:lines() do
@@ -13,12 +16,12 @@ local function execute_command(fmt, ...)
 
 	local tbl_rc = {handle:close()}
 	if tbl_rc[1] ~= true then
-		print(string.format("Error|execute_command|[%s]", string.format(fmt, ...)))
+		print(string_format("Error|execute_command|[%s]", string_format(fmt, ...)))
 		for _, v in ipairs(t) do
-			print(string.format("%s", v))
+			print(string_format("%s", v))
 		end
 		for k, v in pairs(tbl_rc) do
-			print(string.format("k(%s) v(%s)", k, v))
+			print(string_format("k(%s) v(%s)", k, v))
 		end
 		assert(false)
 	end
@@ -26,19 +29,19 @@ local function execute_command(fmt, ...)
 end
 
 local function svn_command(fmt, ...)
-	return execute_command(string.format(_ENV.SVN_CMD .. " " .. fmt, ...))
+	return execute_command(string_format(_ENV.SVN_CMD .. " " .. fmt, ...))
 end
 
 local function string_split(str, sep, func)
 	local tbl_fields = {}
-	local pattern = string.format("([^%s]+)", sep)
+	local pattern = string_format("([^%s]+)", sep)
 
 	if func then
-		string.gsub(str, pattern, function(c)
+		string_gsub(str, pattern, function(c)
 			tbl_fields[#tbl_fields + 1] = func(c) 
 		end)
 	else
-		string.gsub(str, pattern, function(c)
+		string_gsub(str, pattern, function(c)
 			tbl_fields[#tbl_fields + 1] = c 
 		end)
 	end
@@ -48,9 +51,9 @@ end
 local function hash_table_sort(t, sort_func)
 	local array = {}
 	for k, v in pairs(t) do
-		table.insert(array, {key = k, value = v})
+		table_insert(array, {key = k, value = v})
 	end
-	table.sort(array, sort_func)
+	table_sort(array, sort_func)
 	return array
 end
 
@@ -112,12 +115,12 @@ local function merge(commit_log_fmt, svn_relative_to_root_path, svn_log, workdir
 	-- 检查第一行的返回信息 --- Merging rxxx into '/xxx/':
 	local merge_revision = tonumber(tbl_merge_response[1]:match("^%-%-%- Merging r(.*) into .*$"))
 	if not merge_revision then
-		return false, string.format("error|merge|invalid first line of response|%s", tbl_merge_response[1])
+		return false, string_format("error|merge|invalid first line of response|%s", tbl_merge_response[1])
 	end
 
 	-- 返回信息的版本不一致
 	if merge_revision ~= svn_log.revision then
-		return false, string.format("error|merge|merge_revision not match|%s|%s", merge_revision, svn_log.revision)
+		return false, string_format("error|merge|merge_revision not match|%s|%s", merge_revision, svn_log.revision)
 	end
 
 	-- 冲突文件列表
@@ -136,37 +139,37 @@ local function merge(commit_log_fmt, svn_relative_to_root_path, svn_log, workdir
 
 		local op, file = tbl_merge_response[i]:match("^ *(%a) *(%/.*)$")
 		if not tbl_merged_item_op[op] then
-			return false, string.format("error|merge|invalid merged item|%s|%s", tbl_merge_response[i], op)
+			return false, string_format("error|merge|invalid merged item|%s|%s", tbl_merge_response[i], op)
 		end
 
 		-- 检查排除的路径
 		for _, execlude_path in ipairs(tbl_execlude_path) do
 			-- 获取相对于 svn 分支目录的相对路径
-			local relative_to_root_path = file:match(string.format("^%s(.*)", workdir:gsub("%p","%%%0")))
+			local relative_to_root_path = file:match(string_format("^%s(.*)", workdir:gsub("%p","%%%0")))
 
 			if relative_to_root_path:match(execlude_path) then
 				-- revert 过父目录, 子目录不再进行 revert
 				for _, revert_path in ipairs(tbl_revert_path) do
-					if file:match(string.format("^%s(.*)", revert_path:gsub("%p", "%%%0"))) then
+					if file:match(string_format("^%s(.*)", revert_path:gsub("%p", "%%%0"))) then
 						goto continue
 					end
 				end
 
-				print(string.format("\tSkip|file(%s)", relative_to_root_path))
+				print(string_format("\tSkip|file(%s)", relative_to_root_path))
 				revert(file) -- 当文件路径中包含 @ 字符时, 需要在未尾也加上 @
-				table.insert(tbl_revert_path, file)
+				table_insert(tbl_revert_path, file)
 				goto continue
 			end
 		end
 
 		-- 打印合并操作
-		print(string.format("\t%s\t%s", op, file))
+		print(string_format("\t%s\t%s", op, file))
 
 		-- 记录冲突文件并还原
 		if op == 'C' then
 			tbl_conflicts[#tbl_conflicts + 1] = file
 			revert(file)
-			print(string.format("\trevert %s", file)) -- 打印回滚的路径
+			print(string_format("\trevert %s", file)) -- 打印回滚的路径
 		else
 			tbl_normal[#tbl_normal + 1] = file
 		end
@@ -182,8 +185,8 @@ local function merge(commit_log_fmt, svn_relative_to_root_path, svn_log, workdir
 end
 
 local function write_file(file_name, mode, fmt, ...)
-	local f = assert(io.open(file_name, mode), string.format("write_file|file_name(%s)", file_name))
-	local success, msg = f:write(string.format(fmt, ...))
+	local f = assert(io.open(file_name, mode), string_format("write_file|file_name(%s)", file_name))
+	local success, msg = f:write(string_format(fmt, ...))
 	if not success then
 		error(msg)
 	end
@@ -198,14 +201,14 @@ local function read_file(file_name, check_file_exist)
 	local f = io.open(file_name, "r")
 	if not f then
 		if check_file_exist then
-			error(string.format("read_file|file_name(%s)", file_name))
+			error(string_format("read_file|file_name(%s)", file_name))
 		else
 			return ""
 		end
 	end
 	local s = f:read("a")
 	if not s then
-		error(string.format("read_file|file_name(%s)", file_name))
+		error(string_format("read_file|file_name(%s)", file_name))
 	end
 	f:close()
 	return s
@@ -228,8 +231,8 @@ local function check_exclude(svn_log_info, tbl_execlude_rule)
 		end
 
 		-- 排除规则完全匹配
-		-- print(string.format("\tMatch exclude rule|revision(%s)|author(%s)|msg(%s)", execlude_rule.revision, execlude_rule.author, execlude_rule.msg))
-		print(string.format("\tSkip|revision(%s)|author(%s)|msg(%s)", svn_log_info.revision, svn_log_info.author, svn_log_info.msg))
+		-- print(string_format("\tMatch exclude rule|revision(%s)|author(%s)|msg(%s)", execlude_rule.revision, execlude_rule.author, execlude_rule.msg))
+		print(string_format("\tSkip|revision(%s)|author(%s)|msg(%s)", svn_log_info.revision, svn_log_info.author, svn_log_info.msg))
 		
 		if true then
 			return true
@@ -244,7 +247,7 @@ local function get_local_svn_relative_to_root_path(local_path, svn_url)
 	local tbl_response = svn_command("info %s", local_path)
 	for k, v in pairs(tbl_response) do
 		-- URL: http://xxx.xxx
-		local svn_relative_to_root_path = v:match(string.format("^URL: %s(.*)$", svn_url))
+		local svn_relative_to_root_path = v:match(string_format("^URL: %s(.*)$", svn_url))
 		if svn_relative_to_root_path then
 			return svn_relative_to_root_path
 		end
@@ -263,10 +266,10 @@ local function auto_merge(config_file, begin_revision, end_revision)
 	local last_merged_revision_store = config.last_merged_revision_store
 	local tbl_execlude_rule = config.execlude_rule
 	local tbl_execlude_path = config.execlude_path
-	local svn_path = string.format("%s%s", svn_url, svn_relative_to_root_path)
+	local svn_path = string_format("%s%s", svn_url, svn_relative_to_root_path)
 	local last_merged_revision = tonumber(read_file(last_merged_revision_store, false))
 	local commit_log_fmt = config.commit_log_fmt or [[merge from ${from_svn_relative_to_root_path} ${from_revision}]]
-	assert(begin_revision or last_merged_revision, string.format("begin_revision(%s)|last_merged_revision(%s)|you must specify the revision", begin_revision, last_merged_revision))
+	assert(begin_revision or last_merged_revision, string_format("begin_revision(%s)|last_merged_revision(%s)|you must specify the revision", begin_revision, last_merged_revision))
 
 	_ENV.SVN_CMD = config.svn_cmd
 
@@ -300,7 +303,7 @@ local function auto_merge(config_file, begin_revision, end_revision)
 			end
 
 			--
-			print(string.format("merge revision = [%s], author = [%s]", svn_log.revision, svn_log.author))
+			print(string_format("merge revision = [%s], author = [%s]", svn_log.revision, svn_log.author))
 
 			if check_exclude(svn_log, tbl_execlude_rule) then
 				goto continue
@@ -320,10 +323,10 @@ local function auto_merge(config_file, begin_revision, end_revision)
 						tbl_final_report[svn_log.author][svn_log.revision] = tbl_final_report[svn_log.author][svn_log.revision] or {}
 
 						-- 获取相对于 svn 分支目录的相对路径
-						local relative_to_root_path = conflicts_file:match(string.format("^%s(.*)", workdir:gsub("%p","%%%0")))
+						local relative_to_root_path = conflicts_file:match(string_format("^%s(.*)", workdir:gsub("%p","%%%0")))
 						tbl_final_report[svn_log.author][svn_log.revision][#tbl_final_report[svn_log.author][svn_log.revision] + 1] = relative_to_root_path
 
-						f:write(string.format("%s|%s|%s\n", svn_log.author, svn_log.revision, relative_to_root_path))
+						f:write(string_format("%s|%s|%s\n", svn_log.author, svn_log.revision, relative_to_root_path))
 					end
 
 					f:close()
@@ -344,11 +347,11 @@ local function auto_merge(config_file, begin_revision, end_revision)
 		end
 
 		for author, v1 in pairs(tbl_final_report) do
-			f:write(string.format("%s\n", author))
+			f:write(string_format("%s\n", author))
 			for revision, tbl_relative_to_root_path in pairs(v1) do
-				f:write(string.format("\t merge %s %s to %s\n", svn_relative_to_root_path, revision, target))
+				f:write(string_format("\t merge %s %s to %s\n", svn_relative_to_root_path, revision, target))
 				for _, relative_to_root_path in ipairs(tbl_relative_to_root_path) do
-					f:write(string.format("\t\t%s\n", relative_to_root_path))
+					f:write(string_format("\t\t%s\n", relative_to_root_path))
 				end
 			end
 		end
@@ -371,27 +374,27 @@ local function print_conflicts(config_file)
 	local tbl_final_report = {}
 
 	local f = io.open(report_file, "r")
-        if not f then
-                print(string.format("can not found report_file(%s)", report_file))
-                return
-        end
+		if not f then
+			print(string_format("can not found report_file(%s)", report_file))
+			return
+		end
 
-        for line in f:lines() do
-                if line == "" then
-                        goto continue
-                end
+		for line in f:lines() do
+			if line == "" then
+				goto continue
+			end
 
-                local author, revision, file = line:match("(.*)%|(.*)%|(.*)")
-                if not author then
-                        error(string.format("line(%s)", line))
-                end
+			local author, revision, file = line:match("(.*)%|(.*)%|(.*)")
+			if not author then
+				error(string_format("line(%s)", line))
+			end
 
-                tbl_final_report[author] = tbl_final_report[author] or {}
-                tbl_final_report[author][revision] = tbl_final_report[author][revision] or {}
-                tbl_final_report[author][revision][#tbl_final_report[author][revision] + 1] = file
+			tbl_final_report[author] = tbl_final_report[author] or {}
+			tbl_final_report[author][revision] = tbl_final_report[author][revision] or {}
+			tbl_final_report[author][revision][#tbl_final_report[author][revision] + 1] = file
 
-                ::continue::
-        end
+			::continue::
+		end
 
  	f = io.output()
 	if next(tbl_final_report) then
@@ -400,14 +403,14 @@ local function print_conflicts(config_file)
 	end
 
 	for author, v1 in pairs(tbl_final_report) do
-		f:write(string.format("%s\n", author))
+		f:write(string_format("%s\n", author))
 		for _, v2 in pairs(hash_table_sort(v1, function(a, b) return a.key < b.key end)) do -- .key 即为 revision
 			local revision = v2.key
 			local tbl_relative_to_root_path = v2.value
 
-			f:write(string.format("\t merge %s %s to %s\n", svn_relative_to_root_path, revision, target))
+			f:write(string_format("\t merge %s %s to %s\n", svn_relative_to_root_path, revision, target))
 			for _, relative_to_root_path in ipairs(tbl_relative_to_root_path) do
-				f:write(string.format("\t\t%s\n", relative_to_root_path))
+				f:write(string_format("\t\t%s\n", relative_to_root_path))
 			end
 		end
 	end
@@ -423,5 +426,5 @@ local end_revision = tonumber(select(4, ...) or "")
 local tbl_oper_func = {}
 tbl_oper_func["print_conflicts"] = print_conflicts
 tbl_oper_func["auto_merge"] = auto_merge
-local func = assert(tbl_oper_func[oper_type], string.format("Invalid oper_type(%s)", oper_type))
+local func = assert(tbl_oper_func[oper_type], string_format("Invalid oper_type(%s)", oper_type))
 func(config_file, begin_revision, end_revision)

--- a/config_example.lua
+++ b/config_example.lua
@@ -1,9 +1,9 @@
 local config = {
-	svn_cmd = 'svn --username \"xxx\" --password \"xxx\" --no-auth-cache',
-	svn_url = "", -- svn url 地址
-	svn_relative_to_root_path = "", -- 分支目录(相对于 svn url 的路径)
-	workdir = "", -- 本地 svn 目录
-	report_file = "", -- 冲突报告日志
+	svn_cmd = [[svn --username "xxx" --password "xxx" --no-auth-cache]],
+	svn_url = [[]], -- svn url 地址
+	svn_relative_to_root_path = [[]], -- 分支目录(相对于 svn url 的路径)
+	workdir = [[]], -- 本地 svn 目录
+	report_file = [[]], -- 冲突报告日志
 	execlude_rule = {
 		{author = "xxx", msg = "xxx", revision = xxx}, -- 根据 author/msg/revision 中的一个或多个排除不需要合并的版本
 		{author = "xxx"},
@@ -13,6 +13,7 @@ local config = {
 		"xxxx", -- 根据路径排除不需要合并的文件
 		...
 	},
-	last_merged_revision_store = "/path_to_last_merged_revision", -- 程序用于保存最后已经合并过的版本号
+	last_merged_revision_store = [[/path_to_last_merged_revision]], -- 程序用于保存最后已经合并过的版本号
+	commit_log_fmt = [[merge from ${from_svn_relative_to_root_path} ${from_revision}|${from_commit_log}]],
 }
 return config


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kinbei/svn-auto-merge/2)
<!-- Reviewable:end -->
